### PR TITLE
scipy.io.wavfile.read() does not read 1D numpy arrays

### DIFF
--- a/wav2json.py
+++ b/wav2json.py
@@ -121,7 +121,8 @@ if __name__ == "__main__":
     SR, data = scipy.io.wavfile.read(args.ifile)
     if(data.ndim==1):                            #if the numpy array is 1D,it converts into a 2D numpy array. 
         data = numpy.reshape(data, (-1, 2))       
-    M, numChannels = data.shape                     # nr. of samples in input
+    else:
+        M, numChannels = data.shape                     # nr. of samples in input
 
     # convert fixed point audio data to floating point range -1. to 1.
     if data.dtype == 'int16':

--- a/wav2json.py
+++ b/wav2json.py
@@ -119,6 +119,8 @@ if __name__ == "__main__":
     args = parseArgs()
     N = args.samples                                # nr. of samples in output
     SR, data = scipy.io.wavfile.read(args.ifile)
+    if(data.ndim==1):                            #if the numpy array is 1D,it converts into a 2D numpy array. 
+        data = numpy.reshape(data, (-1, 2))       
     M, numChannels = data.shape                     # nr. of samples in input
 
     # convert fixed point audio data to floating point range -1. to 1.


### PR DESCRIPTION
The wav file that I was trying to convert returned a one dimensional numpy array and it was showing an error because a 1D numpy array does not show the number of rows as 1. 
Because of which on line 122: M, numChannels = data.shape  will show an error saying that it expected 2 arguments but it only got one. 


So this is a slight modification to the code. 
Thanks for the upload.